### PR TITLE
Created the hierarchy for Drawables in RWL and implemented Rect class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,15 +10,19 @@ set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/")
 set(INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include/")
 set(RWL "${INCLUDE}rwl/")
 
-set(CPP_FILES
+set(CLASSES
   "Pen"
   "core"
   "Color"
   "Window"
 )
+
+set(CPP_FILES
+)
   
 set(HPP_FILES
   "rwl"
+  "Drawables/Drawable"
 )
 
 set(PCH_FILES
@@ -28,9 +32,14 @@ set(PCH_FILES
 
 set(ALL_FILES)
 
-foreach(file ${CPP_FILES})
+foreach(file ${CLASSES})
   set(ALL_FILES ${ALL_FILES};${RWL}${file}.hpp ${SRC}${file}.cpp)
 endforeach()
+
+foreach(file ${CPP_FILES})
+  set(ALL_FILES ${ALL_FILES};${SRC}${file}.cpp)
+endforeach()
+
 
 foreach(file ${HPP_FILES})
   set(ALL_FILES ${ALL_FILES};${RWL}${file}.hpp)
@@ -42,7 +51,7 @@ foreach(file ${PCH_FILES})
 endforeach()
 
 add_library(rwl
-${ALL_FILES}
+  ${ALL_FILES}
 )
 
 if(WIN32)
@@ -65,10 +74,12 @@ target_include_directories(rwl PUBLIC
 
 target_precompile_headers(rwl PRIVATE
   <cmath>
+  <memory>
   <cstdlib>
   <iostream>
   <xcb/xcb.h>
   <functional>
+  <type_traits>
   ${PCH_EVAL}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,37 @@ set(CLASSES
 
 set(CPP_FILES
 )
-  
+
 set(HPP_FILES
   "rwl"
-  "Drawables/Drawable"
 )
 
 set(PCH_FILES
   "Log"
   "Vec2"
 )
+
+set(RECT
+  "Rect"
+  "RectComm"
+  "RectPtrComm"
+  "RectRefComm"
+)
+
+set(DRAWABLES
+  "Drawable"
+  "DrawableComm"
+)
+
+foreach(file ${RECT})
+  set(${DRAWABLES} ${DRAWABLES};Rect/${file})
+endforeach()
+
+
+foreach(file ${DRAWABLES})
+  set(HPP_FILES ${HPP_FILES};Drawables/${file})
+endforeach()
+
 
 set(ALL_FILES)
 

--- a/include/rwl/Color.hpp
+++ b/include/rwl/Color.hpp
@@ -2,8 +2,6 @@
 #include "rwl/Log.hpp"
 #include "rwl/core.hpp"
 
-// TODO: Add support for other colors.
-
 namespace rwl {
   class Pen;
   class Window;

--- a/include/rwl/Drawables/Drawable.hpp
+++ b/include/rwl/Drawables/Drawable.hpp
@@ -1,0 +1,79 @@
+#pragma once
+#include "rwl/Drawables/DrawableBase.hpp"
+#include "rwl/Log.hpp"
+#include "rwl/Pen.hpp"
+#include "rwl/Window.hpp"
+
+#include <memory>
+#include <xcb/xcb.h>
+
+namespace rwl {
+  template <typename T> // Only works if 3 types of args are supplied
+  class Drawable;
+
+  /*
+   * This is instantiated if an lvalue reference/exisiting Pen is supplied.
+   * This class stores a reference to the existing variable therefore any
+   * changes to that Pen are also reflected here.
+   */
+  template <>
+  class Drawable<Pen &>: public impl::DrawableBase {
+  private:
+    Pen &m_pen;
+
+  public:
+    Drawable(Pen &pen) : m_pen(pen) {
+      impl::log("Created Drawable with lvalue.");
+    }
+
+    Pen &pen() const {
+      impl::log<impl::LogLevel::NoImp>("Returning Pen");
+      return m_pen;
+    }
+  };
+
+  /*
+   * This is for when a rvalue reference/temporary Pen is supplied. As you can't
+   * store a reference to it, a copy is stored.
+   */
+  template <>
+  class Drawable<Pen &&>: public impl::DrawableBase {
+  private:
+    Pen m_pen;
+
+  public:
+    Drawable(Pen &&pen) : m_pen(std::move(pen)) {
+      impl::log("Created Drawable with rvalue.");
+    }
+
+    Pen &pen() {
+      impl::log<impl::LogLevel::NoImp>("Returning Pen");
+      return m_pen;
+    }
+  };
+
+  /*
+   * When the lifetime of you existing pen is shorter you can use this method.
+   * It stores the Pen on the heap with a std::shared_ptr to it. This does come
+   * with some runtime cost of course.
+   */
+  template <>
+  class Drawable<std::shared_ptr<Pen>>: public impl::DrawableBase {
+  private:
+    std::shared_ptr<Pen> m_pen;
+
+  public:
+    Drawable(std::shared_ptr<Pen> pen) : m_pen(pen) {
+      impl::log("Created Drawable with std::shared_ptr");
+    }
+
+    Pen &pen() const {
+      impl::log<impl::LogLevel::NoImp>("Returning Pen");
+      return *m_pen;
+    }
+  };
+
+  Drawable(Pen &)->Drawable<Pen &>;
+  Drawable(Pen &&)->Drawable<Pen &&>;
+  Drawable(std::shared_ptr<Pen>)->Drawable<std::shared_ptr<Pen>>;
+} // namespace rwl

--- a/include/rwl/Drawables/Drawable.hpp
+++ b/include/rwl/Drawables/Drawable.hpp
@@ -18,16 +18,14 @@ namespace rwl {
    */
   template <>
   class Drawable<Pen &>: public impl::DrawableBase {
-  private:
+  protected:
     Pen &m_pen;
 
   public:
-    Drawable(Pen &pen) : m_pen(pen) {
-      impl::log("Created Drawable with lvalue.");
-    }
+    Drawable(Pen &pen) : m_pen(pen) {}
 
     Pen &pen() const {
-      impl::log<impl::LogLevel::NoImp>("Returning Pen");
+      impl::log<impl::LogLevel::NoImp>("Drawable: Returning Pen (lvalue)");
       return m_pen;
     }
   };
@@ -38,16 +36,14 @@ namespace rwl {
    */
   template <>
   class Drawable<Pen &&>: public impl::DrawableBase {
-  private:
+  protected:
     Pen m_pen;
 
   public:
-    Drawable(Pen &&pen) : m_pen(std::move(pen)) {
-      impl::log("Created Drawable with rvalue.");
-    }
+    Drawable(Pen &&pen) : m_pen(std::move(pen)) {}
 
     Pen &pen() {
-      impl::log<impl::LogLevel::NoImp>("Returning Pen");
+      impl::log<impl::LogLevel::NoImp>("Drawable: Returning Pen (rvalue)");
       return m_pen;
     }
   };
@@ -59,21 +55,44 @@ namespace rwl {
    */
   template <>
   class Drawable<std::shared_ptr<Pen>>: public impl::DrawableBase {
-  private:
+  protected:
     std::shared_ptr<Pen> m_pen;
 
   public:
-    Drawable(std::shared_ptr<Pen> pen) : m_pen(pen) {
-      impl::log("Created Drawable with std::shared_ptr");
-    }
+    Drawable(std::shared_ptr<Pen> pen) : m_pen(pen) {}
 
     Pen &pen() const {
-      impl::log<impl::LogLevel::NoImp>("Returning Pen");
+      impl::log<impl::LogLevel::NoImp>(
+          "Drawable: Returning Pen (std::shared_ptr)");
+      return *m_pen;
+    }
+  };
+
+  /*
+   * When you want the Pen to be on the heap but you're passing in a temporary
+   * ptr then this speicialization is used.
+   */
+  template <>
+  class Drawable<std::unique_ptr<Pen>>: public impl::DrawableBase {
+  protected:
+    std::unique_ptr<Pen> m_pen;
+
+  public:
+    Drawable(std::shared_ptr<Pen> &&pen)
+        : m_pen(std::make_unique<Pen>(std::move(*pen))) {}
+
+    Drawable(std::unique_ptr<Pen> &&pen) : m_pen(std::move(pen)) {}
+
+    Pen &pen() const {
+      impl::log<impl::LogLevel::NoImp>(
+          "Drawable: Returning Pen (std::unique_ptr)");
       return *m_pen;
     }
   };
 
   Drawable(Pen &)->Drawable<Pen &>;
   Drawable(Pen &&)->Drawable<Pen &&>;
-  Drawable(std::shared_ptr<Pen>)->Drawable<std::shared_ptr<Pen>>;
+  Drawable(std::shared_ptr<Pen> &)->Drawable<std::shared_ptr<Pen>>;
+  Drawable(std::shared_ptr<Pen> &&)->Drawable<std::unique_ptr<Pen>>;
+  Drawable(std::unique_ptr<Pen> &&)->Drawable<std::unique_ptr<Pen>>;
 } // namespace rwl

--- a/include/rwl/Drawables/Drawable.hpp
+++ b/include/rwl/Drawables/Drawable.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "rwl/Drawables/DrawableBase.hpp"
+#include "rwl/Drawables/DrawableComm.hpp"
 #include "rwl/Log.hpp"
 #include "rwl/Pen.hpp"
 #include "rwl/Window.hpp"
@@ -17,7 +17,7 @@ namespace rwl {
    * changes to that Pen are also reflected here.
    */
   template <>
-  class Drawable<Pen &>: public impl::DrawableBase {
+  class Drawable<Pen &>: public impl::DrawableComm {
   protected:
     Pen &m_pen;
 
@@ -35,7 +35,7 @@ namespace rwl {
    * store a reference to it, a copy is stored.
    */
   template <>
-  class Drawable<Pen &&>: public impl::DrawableBase {
+  class Drawable<Pen &&>: public impl::DrawableComm {
   protected:
     Pen m_pen;
 
@@ -54,7 +54,7 @@ namespace rwl {
    * with some runtime cost of course.
    */
   template <>
-  class Drawable<std::shared_ptr<Pen>>: public impl::DrawableBase {
+  class Drawable<std::shared_ptr<Pen>>: public impl::DrawableComm {
   protected:
     std::shared_ptr<Pen> m_pen;
 
@@ -73,14 +73,11 @@ namespace rwl {
    * ptr then this speicialization is used.
    */
   template <>
-  class Drawable<std::unique_ptr<Pen>>: public impl::DrawableBase {
+  class Drawable<std::unique_ptr<Pen>>: public impl::DrawableComm {
   protected:
     std::unique_ptr<Pen> m_pen;
 
   public:
-    Drawable(std::shared_ptr<Pen> &&pen)
-        : m_pen(std::make_unique<Pen>(std::move(*pen))) {}
-
     Drawable(std::unique_ptr<Pen> &&pen) : m_pen(std::move(pen)) {}
 
     Pen &pen() const {
@@ -93,6 +90,5 @@ namespace rwl {
   Drawable(Pen &)->Drawable<Pen &>;
   Drawable(Pen &&)->Drawable<Pen &&>;
   Drawable(std::shared_ptr<Pen> &)->Drawable<std::shared_ptr<Pen>>;
-  Drawable(std::shared_ptr<Pen> &&)->Drawable<std::unique_ptr<Pen>>;
   Drawable(std::unique_ptr<Pen> &&)->Drawable<std::unique_ptr<Pen>>;
 } // namespace rwl

--- a/include/rwl/Drawables/DrawableBase.hpp
+++ b/include/rwl/Drawables/DrawableBase.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include "rwl/Window.hpp"
+
+namespace rwl::impl {
+  class DrawableBase {
+  public:
+    virtual void drawIn(Window &win) = 0;
+  };
+} // namespace rwl::impl

--- a/include/rwl/Drawables/DrawableBase.hpp
+++ b/include/rwl/Drawables/DrawableBase.hpp
@@ -1,9 +1,0 @@
-#pragma once
-#include "rwl/Window.hpp"
-
-namespace rwl::impl {
-  class DrawableBase {
-  public:
-    virtual void drawIn(Window &win) = 0;
-  };
-} // namespace rwl::impl

--- a/include/rwl/Drawables/DrawableComm.hpp
+++ b/include/rwl/Drawables/DrawableComm.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "rwl/Window.hpp"
+
+namespace rwl::impl {
+  class DrawableComm { // Comm is for common.
+  // All common code between all Drawable specializations lives here
+  public:
+    virtual void drawIn(Window &win) = 0;
+    virtual ~DrawableComm() {} 
+  };
+} // namespace rwl::impl

--- a/include/rwl/Drawables/Rect/Rect.hpp
+++ b/include/rwl/Drawables/Rect/Rect.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "rwl/Drawables/Rect/RectPtrComm.hpp"
+#include "rwl/Drawables/Rect/RectRefComm.hpp"
+#include "rwl/Pen.hpp"
+#include "rwl/Vec2.hpp"
+
+#include <memory>
+#include <utility>
+
+namespace rwl {
+  template <typename T>
+  class Rect;
+
+  // If an existing Pen is passed in use this 1
+  template <>
+  class Rect<Pen &>: public impl::RectRefComm<Pen &> {
+  public:
+    Rect(Pen &pen, const Pos &pos = {0, 0}, const Dim &dim = {10, 10})
+        : impl::RectRefComm<Pen &>(pen, pos, dim) {}
+  };
+
+  // If a temporary Pen is passed in use this 1
+  template <>
+  class Rect<Pen &&>: public impl::RectRefComm<Pen &&> {
+  public:
+    Rect(Pen &&pen = Pen(), const Pos &pos = {0, 0}, const Dim &dim = {10, 10})
+        : impl::RectRefComm<Pen &&>(std::move(pen), pos, dim) {}
+  };
+
+  // If a shared ptr to an existing pen is passed in use this 1
+  template <>
+  class Rect<std::shared_ptr<Pen>>
+      : public impl::RectPtrComm<std::shared_ptr<Pen>> {
+  public:
+    Rect(std::shared_ptr<Pen> pen, const Pos &pos = {0, 0},
+         const Dim &dim = {10, 10})
+        : impl::RectPtrComm<std::shared_ptr<Pen>>(pen, pos, dim) {}
+  };
+
+  template <>
+  class Rect<std::unique_ptr<Pen>>
+      : public impl::RectPtrComm<std::unique_ptr<Pen>> {
+  public:
+    Rect(std::shared_ptr<Pen> &&pen, const Pos &pos = {0, 0},
+         const Dim &dim = {10, 10})
+        : impl::RectPtrComm<std::unique_ptr<Pen>>(
+              std::make_unique<Pen>(std::move(*pen)), pos, dim) {}
+
+    Rect(std::unique_ptr<Pen> &&pen, const Pos &pos = {0, 0},
+         const Dim &dim = {10, 10})
+        : impl::RectPtrComm<std::unique_ptr<Pen>>(std::move(pen), pos, dim) {}
+  };
+
+  // Deduction guidelines
+  Rect(Pen &, ...)->Rect<Pen &>;
+  Rect(Pen &&, ...)->Rect<Pen &&>;
+
+  Rect(std::shared_ptr<Pen>, ...)->Rect<std::shared_ptr<Pen>>;
+
+  Rect(std::shared_ptr<Pen> &&, ...)->Rect<std::unique_ptr<Pen>>;
+  Rect(std::unique_ptr<Pen> &&, ...)->Rect<std::unique_ptr<Pen>>;
+} // namespace rwl

--- a/include/rwl/Drawables/Rect/RectComm.hpp
+++ b/include/rwl/Drawables/Rect/RectComm.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "rwl/Drawables/Drawable.hpp"
+#include "rwl/Vec2.hpp"
+
+#include <type_traits>
+#include <utility>
+#include <xcb/xcb.h>
+
+namespace rwl::impl {
+  // All code common in all Rects lives below
+  template <typename T>
+  class RectComm: public Drawable<T> {
+  protected:
+    xcb_rectangle_t m_rect[1];
+
+  public:
+    RectComm(T pen, const Pos &pos, const Dim &dim)
+        : Drawable<T>(std::forward<std::remove_cv_t<T>>(pen)),
+          m_rect{pos.x, pos.y, dim.width, dim.height} {}
+
+    inline const PosRef getPos() const {
+      return PosRef(this->m_rect->x, this->m_rect->y);
+    }
+    inline const DimRef getDim() const {
+      return DimRef(this->m_rect->width, this->m_rect->height);
+    }
+
+    RectComm &setPos(const Pos &newPos) {
+      this->m_rect->x = newPos.x;
+      this->m_rect->y = newPos.y;
+
+      return *this;
+    }
+
+    RectComm &setDim(const Dim &newDim) {
+      this->m_rect->width = newDim.width;
+      this->m_rect->height = newDim.height;
+
+      return *this;
+    }
+
+    virtual ~RectComm() {}
+  };
+} // namespace rwl::impl

--- a/include/rwl/Drawables/Rect/RectPtrComm.hpp
+++ b/include/rwl/Drawables/Rect/RectPtrComm.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "rwl/Drawables/Rect/RectComm.hpp"
+#include "rwl/Window.hpp"
+#include "rwl/core.hpp"
+#include <xcb/xcb.h>
+
+namespace rwl::impl {
+  /*
+   * All code common between all Rect specializations that have a pointer to a
+   * Pen in them lives here
+   */
+  template <typename T>
+  class RectPtrComm: public RectComm<T> {
+  public:
+    using RectComm<T>::RectComm;
+
+    void drawIn(Window &win) {
+      xcb_poly_rectangle(impl::core::conn, win.m_win, this->m_pen->m_pen, 1,
+                         this->m_rect);
+    }
+
+    virtual ~RectPtrComm() {}
+  };
+} // namespace rwl::impl

--- a/include/rwl/Drawables/Rect/RectRefComm.hpp
+++ b/include/rwl/Drawables/Rect/RectRefComm.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "rwl/Drawables/Rect/RectComm.hpp"
+#include "rwl/core.hpp"
+
+namespace rwl::impl {
+  /*
+   * All specializations of Rect that contain either a reference to a Pen or a
+   * Pen should inherit from this class as this contains all common code for
+   * them.
+   */
+  template <typename T>
+  class RectRefComm: public RectComm<T> {
+  public:
+    using RectComm<T>::RectComm;
+
+    void drawIn(Window &win) {
+      xcb_poly_rectangle(impl::core::conn, win.m_win, this->m_pen.m_pen, 1,
+                         this->m_rect);
+    }
+
+    virtual ~RectRefComm() {}
+  };
+} // namespace rwl::impl

--- a/include/rwl/Log.hpp
+++ b/include/rwl/Log.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>
+#include <stdio.h>
 
 #define SET_COLOR(x) "\x1b[" #x "m"
 

--- a/include/rwl/Pen.hpp
+++ b/include/rwl/Pen.hpp
@@ -22,7 +22,6 @@ namespace rwl {
 #endif
 
   private:
-    void create();
     Pen &change();
 
   public:

--- a/include/rwl/Pen.hpp
+++ b/include/rwl/Pen.hpp
@@ -4,6 +4,14 @@
 #include <xcb/xcb.h>
 
 namespace rwl {
+  namespace impl {
+    template <typename T>
+    class RectPtrComm;
+
+    template <typename T>
+    class RectRefComm;
+  } // namespace impl
+
   class Pen {
   public:
     enum class LineStyle : uint32_t {
@@ -92,5 +100,11 @@ namespace rwl {
 #endif
 
     ~Pen();
+
+    template <typename T>
+    friend class impl::RectPtrComm;
+
+    template <typename T>
+    friend class impl::RectRefComm;
   };
 } // namespace rwl

--- a/include/rwl/Vec2.hpp
+++ b/include/rwl/Vec2.hpp
@@ -214,4 +214,6 @@ namespace rwl {
 
   using Pos = Vec2<int16_t>;
   using Dim = Vec2<uint16_t>;
+  using PosRef = Vec2<int16_t &>;
+  using DimRef = Vec2<uint16_t &>;
 } // namespace rwl

--- a/include/rwl/Vec2.hpp
+++ b/include/rwl/Vec2.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cmath>
 #include <iostream>
+#include <type_traits>
 
 namespace rwl {
   template <typename T>

--- a/include/rwl/Window.hpp
+++ b/include/rwl/Window.hpp
@@ -13,10 +13,6 @@ namespace rwl {
     Pos m_pos;
     Color m_bgColor;
 #endif
-
-  private:
-    void createWin() const;
-
   public:
     explicit Window(Window &&other);
     explicit Window(const Window &other);
@@ -32,37 +28,41 @@ namespace rwl {
     Window &hideNoUpdate();
 
     inline const Dim &getDim() const {
-      impl::log("Returning Window Dimensions as ", m_dim);
+      impl::log<impl::LogLevel::NoImp>("Returning Window Dimensions as ",
+                                       m_dim);
       return m_dim;
     }
     inline const Pos &getPos() const {
-      impl::log("Returning Window Position as ", m_pos);
+      impl::log<impl::LogLevel::NoImp>("Returning Window Position as ", m_pos);
       return m_pos;
     }
     inline const Color &getBgColor() const {
-      impl::log("Returning Bg Color as ", this->m_bgColor.colorToStr());
+      impl::log<impl::LogLevel::NoImp>("Returning Bg Color as ",
+                                       this->m_bgColor.colorToStr());
       return this->m_bgColor;
     }
 
     inline Window &setDim(const Dim &other) {
       this->m_dim = other;
-      impl::log("Set Window Dimensions to ", this->m_dim);
+      impl::log<impl::LogLevel::NoImp>("Set Window Dimensions to ",
+                                       this->m_dim);
       return *this;
     }
     inline Window &setPos(const Pos &other) {
       this->m_pos = other;
-      impl::log("Set Window Position to ", this->m_pos);
+      impl::log<impl::LogLevel::NoImp>("Set Window Position to ", this->m_pos);
       return *this;
     }
     inline const Window &setBgColor(const Color &bgColor) {
       this->m_bgColor = bgColor;
-      impl::log("Set Bg Color to ", this->m_bgColor.colorToStr());
+      impl::log<impl::LogLevel::NoImp>("Set Bg Color to ",
+                                       this->m_bgColor.colorToStr());
       return *this;
     }
 
 #if RWL_DEBUG == 1
     inline const xcb_window_t &getW() const {
-      impl::log("Returning Window id.");
+      impl::log<impl::LogLevel::NoImp>("Returning Window id.");
       return m_win;
     }
 #endif

--- a/include/rwl/Window.hpp
+++ b/include/rwl/Window.hpp
@@ -5,6 +5,14 @@
 #include <xcb/xcb.h>
 
 namespace rwl {
+  namespace impl {
+    template <typename T>
+    class RectPtrComm;
+
+    template <typename T>
+    class RectPtrComm;
+  } // namespace impl
+
   class Window {
   private:
 #if RWL_PLATFORM == LINUX
@@ -68,5 +76,11 @@ namespace rwl {
 #endif
 
     ~Window();
+
+    template <typename T>
+    friend class impl::RectPtrComm;
+
+    template <typename T>
+    friend class impl::RectRefComm;
   };
 } // namespace rwl

--- a/include/rwl/Window.hpp
+++ b/include/rwl/Window.hpp
@@ -4,14 +4,6 @@
 #include "rwl/Vec2.hpp"
 #include <xcb/xcb.h>
 
-// TODO: Pos arg of constructor should actually change the pos of the window.
-/* TODO: getDim and getPos should return the actual window dims and pos rather
-         than pre-defined ones. */
-/* TODO: setDim, setPos and setBgColor should actually change the window's pos,
-         dim and bgColor */
-// TODO: fix hide() and hideNoUpdate()
-// TODO: Create Something like a root window
-
 namespace rwl {
   class Window {
   private:

--- a/include/rwl/core.hpp
+++ b/include/rwl/core.hpp
@@ -1,12 +1,14 @@
 #pragma once
 #include "rwl/Log.hpp"
 #include <functional>
+#include <memory>
 #include <xcb/xcb.h>
 
 namespace rwl {
   class Pen;
   class Color;
   class Window;
+
   enum class Measurement { Pixels = 0, Mm };
 
   namespace impl {
@@ -21,6 +23,12 @@ namespace rwl {
   uint16_t height(const Measurement &m = Measurement::Pixels);
 
   namespace impl {
+    template <typename T>
+    class RectPtrComm;
+
+    template <typename T>
+    class RectRefComm;
+
     struct core {
     private:
 #if RWL_PLATFORM == LINUX
@@ -30,9 +38,15 @@ namespace rwl {
 
       core() = delete;
 
-      friend Pen;
-      friend Color;
-      friend Window;
+      friend ::rwl::Pen;
+      friend ::rwl::Color;
+      friend ::rwl::Window;
+
+      template <typename T>
+      friend class RectPtrComm;
+
+      template <typename T>
+      friend class RectRefComm;
 
       friend void ::rwl::end();
       friend void ::rwl::update();

--- a/include/rwl/rwl.hpp
+++ b/include/rwl/rwl.hpp
@@ -2,6 +2,7 @@
 
 #include "rwl/Color.hpp"
 #include "rwl/Drawables/Drawable.hpp"
+#include "rwl/Drawables/Rect/Rect.hpp"
 #include "rwl/Pen.hpp"
 #include "rwl/Vec2.hpp"
 #include "rwl/Window.hpp"

--- a/include/rwl/rwl.hpp
+++ b/include/rwl/rwl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rwl/Color.hpp"
+#include "rwl/Drawables/Drawable.hpp"
 #include "rwl/Pen.hpp"
 #include "rwl/Vec2.hpp"
 #include "rwl/Window.hpp"

--- a/src/Pen.cpp
+++ b/src/Pen.cpp
@@ -21,17 +21,6 @@ namespace rwl {
                               XCB_GC_GRAPHICS_EXPOSURES;
 
   /*************************** Private Functions ***************************/
-  void Pen::create() {
-#if RWL_PLATFORM == LINUX
-    CREATE_PEN_MASK;
-
-    xcb_create_gc(rwl::impl::core::conn, this->m_pen, impl::core::scr->root,
-                  this->s_valueMask, penMask);
-
-    LOGGING_HELPER("Created");
-#endif
-  }
-
   Pen &Pen::change() {
 #if RWL_PLATFORM == LINUX
     CREATE_PEN_MASK;
@@ -52,18 +41,22 @@ namespace rwl {
     LOGGING_HELPER("Moved");
   }
 
-  Pen::Pen(const Pen &other) // Copy Constructor
-      : m_pen(xcb_generate_id(impl::core::conn)), m_fgColor(other.m_fgColor),
-        m_bgColor(other.m_bgColor), m_lineWidth(other.m_lineWidth),
-        m_lineStyle(other.m_lineStyle) {
-    this->create();
+  Pen::Pen(const Pen &other) {
+    Pen(other.m_fgColor, other.m_bgColor, other.m_lineWidth, other.m_lineStyle);
   }
 
   Pen::Pen(const Color &fgColor, const Color &bgColor,
-           const uint32_t &lineWidth, const LineStyle &lineStyle) // Default
+           const uint32_t &lineWidth, const LineStyle &lineStyle)
       : m_pen(xcb_generate_id(impl::core::conn)), m_fgColor(fgColor),
         m_bgColor(bgColor), m_lineWidth(lineWidth), m_lineStyle(lineStyle) {
-    this->create();
+#if RWL_PLATFORM == LINUX
+    CREATE_PEN_MASK;
+
+    xcb_create_gc(rwl::impl::core::conn, this->m_pen, impl::core::scr->root,
+                  this->s_valueMask, penMask);
+
+    LOGGING_HELPER("Created");
+#endif
   }
 
   /******************************** Operators ********************************/

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -2,7 +2,20 @@
 #include "rwl/core.hpp"
 
 namespace rwl {
-  void Window::createWin() const {
+  Window::Window(Window &&other)
+      : m_win(other.m_win), m_dim(other.m_dim), m_pos(other.m_pos),
+        m_bgColor(other.m_bgColor) {
+    impl::log("Moved a window with window Id: ", m_win);
+    other.m_win = 0;
+  }
+
+  Window::Window(const Window &other) {
+    Window(other.m_dim, other.m_pos, other.m_bgColor);
+  }
+
+  Window::Window(const Dim &dim, const Pos &pos, const Color &bgColor)
+      : m_win(xcb_generate_id(impl::core::conn)), m_dim(dim), m_pos(pos),
+        m_bgColor(bgColor) {
 #if RWL_PLATFORM == LINUX
     uint32_t props[2] = {this->m_bgColor.m_color, XCB_EVENT_MASK_EXPOSURE};
 
@@ -14,25 +27,6 @@ namespace rwl {
                       XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK, &props);
     impl::log("Created a window with window Id: ", m_win);
 #endif
-  }
-
-  Window::Window(Window &&other)
-      : m_win(other.m_win), m_dim(other.m_dim), m_pos(other.m_pos),
-        m_bgColor(other.m_bgColor) {
-    impl::log("Moved a window with window Id: ", m_win);
-    other.m_win = 0;
-  }
-
-  Window::Window(const Window &other)
-      : m_win(xcb_generate_id(impl::core::conn)), m_dim(other.m_dim),
-        m_pos(other.m_pos), m_bgColor(other.m_bgColor) {
-    createWin();
-  }
-
-  Window::Window(const Dim &dim, const Pos &pos, const Color &bgColor)
-      : m_win(xcb_generate_id(impl::core::conn)), m_dim(dim), m_pos(pos),
-        m_bgColor(bgColor) {
-    createWin();
   }
 
   Window &Window::operator=(const Window &other) {
@@ -78,5 +72,10 @@ namespace rwl {
     return *this;
   }
 
-  Window::~Window() { xcb_destroy_window(impl::core::conn, m_win); }
+  Window::~Window() {
+#if RWL_PLATFORM == LINUX
+    xcb_destroy_window(impl::core::conn, m_win);
+#endif
+    impl::log("Window Destroyed");
+  }
 } // namespace rwl


### PR DESCRIPTION
Nearly all setters, getters and other function for Rect have been implemented. Any common code is abstracted away in a base called called RectBase or in the case of Drawble --> DrawableBase