### PR TITLE
The position is now the first parameter in rwl::Window.

### DIFF
--- a/include/rwl/Drawables/DrawableComm.hpp
+++ b/include/rwl/Drawables/DrawableComm.hpp
@@ -3,9 +3,9 @@
 
 namespace rwl::impl {
   class DrawableComm { // Comm is for common.
-  // All common code between all Drawable specializations lives here
+    // All common code between all Drawable specializations lives here
   public:
     virtual void drawIn(Window &win) = 0;
-    virtual ~DrawableComm() {} 
+    virtual ~DrawableComm() {}
   };
 } // namespace rwl::impl

--- a/include/rwl/Window.hpp
+++ b/include/rwl/Window.hpp
@@ -17,14 +17,14 @@ namespace rwl {
   private:
 #if RWL_PLATFORM == LINUX
     xcb_window_t m_win;
-    Dim m_dim;
     Pos m_pos;
+    Dim m_dim;
     Color m_bgColor;
 #endif
   public:
     explicit Window(Window &&other);
     explicit Window(const Window &other);
-    Window(const Dim &dim = {640, 480}, const Pos &pos = {0, 0},
+    Window(const Pos &pos = {0, 0}, const Dim &dim = {640, 480},
            const Color &bgColor = Color::White);
 
     Window &operator=(const Window &other);
@@ -35,14 +35,14 @@ namespace rwl {
     Window &hide();
     Window &hideNoUpdate();
 
+    inline const Pos &getPos() const {
+      impl::log<impl::LogLevel::NoImp>("Returning Window Position as ", m_pos);
+      return m_pos;
+    }
     inline const Dim &getDim() const {
       impl::log<impl::LogLevel::NoImp>("Returning Window Dimensions as ",
                                        m_dim);
       return m_dim;
-    }
-    inline const Pos &getPos() const {
-      impl::log<impl::LogLevel::NoImp>("Returning Window Position as ", m_pos);
-      return m_pos;
     }
     inline const Color &getBgColor() const {
       impl::log<impl::LogLevel::NoImp>("Returning Bg Color as ",
@@ -50,15 +50,15 @@ namespace rwl {
       return this->m_bgColor;
     }
 
+    inline Window &setPos(const Pos &other) {
+      this->m_pos = other;
+      impl::log<impl::LogLevel::NoImp>("Set Window Position to ", this->m_pos);
+      return *this;
+    }
     inline Window &setDim(const Dim &other) {
       this->m_dim = other;
       impl::log<impl::LogLevel::NoImp>("Set Window Dimensions to ",
                                        this->m_dim);
-      return *this;
-    }
-    inline Window &setPos(const Pos &other) {
-      this->m_pos = other;
-      impl::log<impl::LogLevel::NoImp>("Set Window Position to ", this->m_pos);
       return *this;
     }
     inline const Window &setBgColor(const Color &bgColor) {

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -10,11 +10,11 @@ namespace rwl {
   }
 
   Window::Window(const Window &other) {
-    Window(other.m_dim, other.m_pos, other.m_bgColor);
+    Window(other.m_pos, other.m_dim, other.m_bgColor);
   }
 
-  Window::Window(const Dim &dim, const Pos &pos, const Color &bgColor)
-      : m_win(xcb_generate_id(impl::core::conn)), m_dim(dim), m_pos(pos),
+  Window::Window(const Pos &pos, const Dim &dim, const Color &bgColor)
+      : m_win(xcb_generate_id(impl::core::conn)), m_pos(pos), m_dim(dim),
         m_bgColor(bgColor) {
 #if RWL_PLATFORM == LINUX
     uint32_t props[2] = {this->m_bgColor.m_color, XCB_EVENT_MASK_EXPOSURE};


### PR DESCRIPTION
This was done to keep uniformity between rwl::Drawables and rwl::Window