### PR TITLE
Added a way so that the user can choose the root of the window they're creating.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CLASSES
   "Pen"
   "core"
   "Color"
-  "Window"
+  "Window/WinComm"
+  "Window/Window"
 )
 
 set(CPP_FILES
@@ -41,31 +42,34 @@ set(DRAWABLES
   "DrawableComm"
 )
 
+# Add Rect/ to every file specified in RECT and save it in DRAWABLE
 foreach(file ${RECT})
   set(${DRAWABLES} ${DRAWABLES};Rect/${file})
 endforeach()
 
-
+# Add Drawable/ to every file specified in DRAWABLE and save it in HPP_FILES
 foreach(file ${DRAWABLES})
   set(HPP_FILES ${HPP_FILES};Drawables/${file})
 endforeach()
 
-
 set(ALL_FILES)
 
+# For every file in CLASSES, add the path to it and an extension and save it in ALL_FILES
 foreach(file ${CLASSES})
   set(ALL_FILES ${ALL_FILES};${RWL}${file}.hpp ${SRC}${file}.cpp)
 endforeach()
 
+# For every file in CPP_FILES, add the path to it and .cpp extension and save it to ALL_FILES
 foreach(file ${CPP_FILES})
   set(ALL_FILES ${ALL_FILES};${SRC}${file}.cpp)
 endforeach()
 
-
+# For every file in HPP_FILES, add the path and .hpp extension to it and save it to ALL_FILES
 foreach(file ${HPP_FILES})
   set(ALL_FILES ${ALL_FILES};${RWL}${file}.hpp)
 endforeach()
 
+# For every file in PCH_FILES add the path and .hpp extension to it and save it in PCH_FILES and ALL_FILES
 foreach(file ${PCH_FILES})
   set(PCH_EVAL ${PCH_EVAL};${RWL}${file}.hpp)
   set(ALL_FILES ${ALL_FILES};${RWL}${file}.hpp)

--- a/include/rwl/Color.hpp
+++ b/include/rwl/Color.hpp
@@ -4,7 +4,9 @@
 
 namespace rwl {
   class Pen;
-  class Window;
+  namespace impl {
+    class WinComm;
+  } // namespace impl
 
   class Color {
   private:
@@ -29,6 +31,6 @@ namespace rwl {
 #endif
 
     friend Pen;
-    friend Window;
+    friend impl::WinComm;
   };
 } // namespace rwl

--- a/include/rwl/Color.hpp
+++ b/include/rwl/Color.hpp
@@ -4,6 +4,7 @@
 
 namespace rwl {
   class Pen;
+  class Window;
   namespace impl {
     class WinComm;
   } // namespace impl
@@ -31,6 +32,7 @@ namespace rwl {
 #endif
 
     friend Pen;
+    friend Window;
     friend impl::WinComm;
   };
 } // namespace rwl

--- a/include/rwl/Drawables/Drawable.hpp
+++ b/include/rwl/Drawables/Drawable.hpp
@@ -2,7 +2,7 @@
 #include "rwl/Drawables/DrawableComm.hpp"
 #include "rwl/Log.hpp"
 #include "rwl/Pen.hpp"
-#include "rwl/Window.hpp"
+#include "rwl/Window/Window.hpp"
 
 #include <memory>
 #include <xcb/xcb.h>

--- a/include/rwl/Drawables/DrawableComm.hpp
+++ b/include/rwl/Drawables/DrawableComm.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "rwl/Window.hpp"
+#include "rwl/Window/Window.hpp"
 
 namespace rwl::impl {
   class DrawableComm { // Comm is for common.

--- a/include/rwl/Drawables/Rect/RectPtrComm.hpp
+++ b/include/rwl/Drawables/Rect/RectPtrComm.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "rwl/Drawables/Rect/RectComm.hpp"
-#include "rwl/Window.hpp"
+#include "rwl/Window/Window.hpp"
 #include "rwl/core.hpp"
 #include <xcb/xcb.h>
 

--- a/include/rwl/Drawables/Rect/RectRefComm.hpp
+++ b/include/rwl/Drawables/Rect/RectRefComm.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rwl/Drawables/Rect/RectComm.hpp"
+#include "rwl/Window/Window.hpp"
 #include "rwl/core.hpp"
 
 namespace rwl::impl {

--- a/include/rwl/Window/WinComm.hpp
+++ b/include/rwl/Window/WinComm.hpp
@@ -4,17 +4,15 @@
 #include "rwl/Vec2.hpp"
 #include <xcb/xcb.h>
 
-namespace rwl {
-  namespace impl {
-    template <typename T>
-    class RectPtrComm;
+namespace rwl::impl {
+  template <typename T>
+  class RectPtrComm;
 
-    template <typename T>
-    class RectPtrComm;
-  } // namespace impl
+  template <typename T>
+  class RectPtrComm;
 
-  class Window {
-  private:
+  class WinComm {
+  protected:
 #if RWL_PLATFORM == LINUX
     xcb_window_t m_win;
     Pos m_pos;
@@ -22,25 +20,23 @@ namespace rwl {
     Color m_bgColor;
 #endif
   public:
-    explicit Window(Window &&other);
-    explicit Window(const Window &other);
-    Window(const Pos &pos = {0, 0}, const Dim &dim = {640, 480},
-           const Color &bgColor = Color::White);
+    WinComm(const xcb_window_t &winId, const Pos &pos, const Dim &dim,
+            const Color &bgColor);
 
-    Window &operator=(const Window &other);
+    WinComm &operator=(const WinComm &other);
 
-    Window &show();
-    Window &showNoUpdate();
+    WinComm &show();
+    WinComm &showNoUpdate();
 
-    Window &hide();
-    Window &hideNoUpdate();
+    WinComm &hide();
+    WinComm &hideNoUpdate();
 
     inline const Pos &getPos() const {
-      impl::log<impl::LogLevel::NoImp>("Returning Window Position as ", m_pos);
+      impl::log<impl::LogLevel::NoImp>("Returning WinComm Position as ", m_pos);
       return m_pos;
     }
     inline const Dim &getDim() const {
-      impl::log<impl::LogLevel::NoImp>("Returning Window Dimensions as ",
+      impl::log<impl::LogLevel::NoImp>("Returning WinComm Dimensions as ",
                                        m_dim);
       return m_dim;
     }
@@ -50,18 +46,18 @@ namespace rwl {
       return this->m_bgColor;
     }
 
-    inline Window &setPos(const Pos &other) {
+    inline WinComm &setPos(const Pos &other) {
       this->m_pos = other;
-      impl::log<impl::LogLevel::NoImp>("Set Window Position to ", this->m_pos);
+      impl::log<impl::LogLevel::NoImp>("Set WinComm Position to ", this->m_pos);
       return *this;
     }
-    inline Window &setDim(const Dim &other) {
+    inline WinComm &setDim(const Dim &other) {
       this->m_dim = other;
-      impl::log<impl::LogLevel::NoImp>("Set Window Dimensions to ",
+      impl::log<impl::LogLevel::NoImp>("Set WinComm Dimensions to ",
                                        this->m_dim);
       return *this;
     }
-    inline const Window &setBgColor(const Color &bgColor) {
+    inline const WinComm &setBgColor(const Color &bgColor) {
       this->m_bgColor = bgColor;
       impl::log<impl::LogLevel::NoImp>("Set Bg Color to ",
                                        this->m_bgColor.colorToStr());
@@ -70,12 +66,12 @@ namespace rwl {
 
 #if RWL_DEBUG == 1
     inline const xcb_window_t &getW() const {
-      impl::log<impl::LogLevel::NoImp>("Returning Window id.");
+      impl::log<impl::LogLevel::NoImp>("Returning WinComm id.");
       return m_win;
     }
 #endif
 
-    ~Window();
+    virtual ~WinComm() {}
 
     template <typename T>
     friend class impl::RectPtrComm;
@@ -83,4 +79,4 @@ namespace rwl {
     template <typename T>
     friend class impl::RectRefComm;
   };
-} // namespace rwl
+} // namespace rwl::impl

--- a/include/rwl/Window/WinComm.hpp
+++ b/include/rwl/Window/WinComm.hpp
@@ -4,15 +4,18 @@
 #include "rwl/Vec2.hpp"
 #include <xcb/xcb.h>
 
-namespace rwl::impl {
-  template <typename T>
-  class RectPtrComm;
+namespace rwl {
+  class Window;
 
-  template <typename T>
-  class RectPtrComm;
+  namespace impl {
+    template <typename T>
+    class RectPtrComm;
 
-  class WinComm {
-  protected:
+    template <typename T>
+    class RectPtrComm;
+
+    class WinComm {
+    protected:
 #if RWL_PLATFORM == LINUX
     xcb_window_t m_win;
     Pos m_pos;
@@ -32,11 +35,11 @@ namespace rwl::impl {
     WinComm &hideNoUpdate();
 
     inline const Pos &getPos() const {
-      impl::log<impl::LogLevel::NoImp>("Returning WinComm Position as ", m_pos);
+      impl::log<impl::LogLevel::NoImp>("Returning Window Position as ", m_pos);
       return m_pos;
     }
     inline const Dim &getDim() const {
-      impl::log<impl::LogLevel::NoImp>("Returning WinComm Dimensions as ",
+      impl::log<impl::LogLevel::NoImp>("Returning Window Dimensions as ",
                                        m_dim);
       return m_dim;
     }
@@ -48,12 +51,12 @@ namespace rwl::impl {
 
     inline WinComm &setPos(const Pos &other) {
       this->m_pos = other;
-      impl::log<impl::LogLevel::NoImp>("Set WinComm Position to ", this->m_pos);
+      impl::log<impl::LogLevel::NoImp>("Set Window Position to ", this->m_pos);
       return *this;
     }
     inline WinComm &setDim(const Dim &other) {
       this->m_dim = other;
-      impl::log<impl::LogLevel::NoImp>("Set WinComm Dimensions to ",
+      impl::log<impl::LogLevel::NoImp>("Set Window Dimensions to ",
                                        this->m_dim);
       return *this;
     }
@@ -66,7 +69,7 @@ namespace rwl::impl {
 
 #if RWL_DEBUG == 1
     inline const xcb_window_t &getW() const {
-      impl::log<impl::LogLevel::NoImp>("Returning WinComm id.");
+      impl::log<impl::LogLevel::NoImp>("Returning Window id.");
       return m_win;
     }
 #endif
@@ -78,5 +81,9 @@ namespace rwl::impl {
 
     template <typename T>
     friend class impl::RectRefComm;
+
+    friend ::rwl::Window;
   };
-} // namespace rwl::impl
+  
+  } // namespace impl
+} // namespace rwl

--- a/include/rwl/Window/Window.hpp
+++ b/include/rwl/Window/Window.hpp
@@ -1,13 +1,21 @@
 #pragma once
 #include "rwl/Window/WinComm.hpp"
+#include "rwl/core.hpp"
 
 namespace rwl {
   class Window: public impl::WinComm {
+  private:
+    void create();
+    const WinComm &m_parent;
+
   public:
     explicit Window(Window &&other);
     explicit Window(const Window &other);
     Window(const Pos &pos = {0, 0}, const Dim &dim = {640, 480},
-           const Color &bgColor = Color::White);
+           const Color &bgColor = Color::White,
+           const impl::WinComm &parent = root);
+    // Window(const Pos &pos, const Dim &dim, const Color &bgColor,
+    //        const WinComm &parent);
 
     ~Window() override;
   };

--- a/include/rwl/Window/Window.hpp
+++ b/include/rwl/Window/Window.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "rwl/Window/WinComm.hpp"
+
+namespace rwl {
+  class Window: public impl::WinComm {
+  public:
+    explicit Window(Window &&other);
+    explicit Window(const Window &other);
+    Window(const Pos &pos = {0, 0}, const Dim &dim = {640, 480},
+           const Color &bgColor = Color::White);
+
+    ~Window() override;
+  };
+} // namespace rwl

--- a/include/rwl/core.hpp
+++ b/include/rwl/core.hpp
@@ -20,6 +20,8 @@ namespace rwl {
 
     template <typename T>
     class RectRefComm;
+
+    const WinComm makeRoot();
   }
 
   void end();
@@ -28,6 +30,7 @@ namespace rwl {
   void loop(std::function<void(bool &finished)> func);
   uint16_t width(const Measurement &m = Measurement::Pixels);
   uint16_t height(const Measurement &m = Measurement::Pixels);
+  extern const impl::WinComm root;
 
   namespace impl {
     struct core {
@@ -50,6 +53,8 @@ namespace rwl {
 
       template <typename T>
       friend class RectRefComm;
+
+      friend const WinComm makeRoot();
 
       friend void ::rwl::end();
       friend void ::rwl::update();

--- a/include/rwl/core.hpp
+++ b/include/rwl/core.hpp
@@ -13,6 +13,13 @@ namespace rwl {
 
   namespace impl {
     struct core;
+    class WinComm;
+    
+    template <typename T>
+    class RectPtrComm;
+
+    template <typename T>
+    class RectRefComm;
   }
 
   void end();
@@ -23,12 +30,6 @@ namespace rwl {
   uint16_t height(const Measurement &m = Measurement::Pixels);
 
   namespace impl {
-    template <typename T>
-    class RectPtrComm;
-
-    template <typename T>
-    class RectRefComm;
-
     struct core {
     private:
 #if RWL_PLATFORM == LINUX
@@ -41,6 +42,8 @@ namespace rwl {
       friend ::rwl::Pen;
       friend ::rwl::Color;
       friend ::rwl::Window;
+      
+      friend WinComm;
 
       template <typename T>
       friend class RectPtrComm;

--- a/include/rwl/rwl.hpp
+++ b/include/rwl/rwl.hpp
@@ -5,5 +5,5 @@
 #include "rwl/Drawables/Rect/Rect.hpp"
 #include "rwl/Pen.hpp"
 #include "rwl/Vec2.hpp"
-#include "rwl/Window.hpp"
+#include "rwl/Window/Window.hpp"
 #include "rwl/core.hpp"

--- a/src/Window/WinComm.cpp
+++ b/src/Window/WinComm.cpp
@@ -4,19 +4,7 @@
 namespace rwl::impl {
   WinComm::WinComm(const xcb_window_t &winId, const Pos &pos, const Dim &dim,
                    const Color &bgColor)
-      : m_win(winId), m_pos(pos), m_dim(dim), m_bgColor(bgColor) {
-#if RWL_PLATFORM == LINUX
-    uint32_t props[2] = {this->m_bgColor.m_color, XCB_EVENT_MASK_EXPOSURE};
-
-    xcb_create_window(impl::core::conn, impl::core::scr->root_depth, m_win,
-                      impl::core::scr->root, this->m_pos.x, this->m_pos.y,
-                      this->m_dim.width, this->m_dim.height, 0,
-                      XCB_WINDOW_CLASS_INPUT_OUTPUT,
-                      impl::core::scr->root_visual,
-                      XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK, &props);
-    impl::log("Created a window with window Id: ", m_win);
-#endif
-  }
+      : m_win(winId), m_pos(pos), m_dim(dim), m_bgColor(bgColor) {}
 
   WinComm &WinComm::operator=(const WinComm &other) {
     setDim(other.m_dim);

--- a/src/Window/WinComm.cpp
+++ b/src/Window/WinComm.cpp
@@ -1,21 +1,10 @@
-#include "rwl/Window.hpp"
+#include "rwl/Window/WinComm.hpp"
 #include "rwl/core.hpp"
 
-namespace rwl {
-  Window::Window(Window &&other)
-      : m_win(other.m_win), m_pos(other.m_pos), m_dim(other.m_dim),
-        m_bgColor(other.m_bgColor) {
-    impl::log("Moved a window with window Id: ", m_win);
-    other.m_win = 0;
-  }
-
-  Window::Window(const Window &other) {
-    Window(other.m_pos, other.m_dim, other.m_bgColor);
-  }
-
-  Window::Window(const Pos &pos, const Dim &dim, const Color &bgColor)
-      : m_win(xcb_generate_id(impl::core::conn)), m_pos(pos), m_dim(dim),
-        m_bgColor(bgColor) {
+namespace rwl::impl {
+  WinComm::WinComm(const xcb_window_t &winId, const Pos &pos, const Dim &dim,
+                   const Color &bgColor)
+      : m_win(winId), m_pos(pos), m_dim(dim), m_bgColor(bgColor) {
 #if RWL_PLATFORM == LINUX
     uint32_t props[2] = {this->m_bgColor.m_color, XCB_EVENT_MASK_EXPOSURE};
 
@@ -29,7 +18,7 @@ namespace rwl {
 #endif
   }
 
-  Window &Window::operator=(const Window &other) {
+  WinComm &WinComm::operator=(const WinComm &other) {
     setDim(other.m_dim);
     setPos(other.m_pos);
 
@@ -38,7 +27,7 @@ namespace rwl {
     return *this;
   }
 
-  Window &Window::show() {
+  WinComm &WinComm::show() {
     showNoUpdate();
     update();
 
@@ -47,7 +36,7 @@ namespace rwl {
     return *this;
   }
 
-  Window &Window::showNoUpdate() {
+  WinComm &WinComm::showNoUpdate() {
     xcb_map_window(impl::core::conn, m_win);
 
     impl::log("Mapped window. Better call update if you haven't already!");
@@ -55,7 +44,7 @@ namespace rwl {
     return *this;
   }
 
-  Window &Window::hide() {
+  WinComm &WinComm::hide() {
     hideNoUpdate();
     update();
 
@@ -64,18 +53,11 @@ namespace rwl {
     return *this;
   }
 
-  Window &Window::hideNoUpdate() {
+  WinComm &WinComm::hideNoUpdate() {
     xcb_unmap_window(impl::core::conn, m_win);
 
-    impl::log("Unmapped Window. Call update if you haven't already.");
+    impl::log("Unmapped WinComm. Call update if you haven't already.");
 
     return *this;
   }
-
-  Window::~Window() {
-#if RWL_PLATFORM == LINUX
-    xcb_destroy_window(impl::core::conn, m_win);
-#endif
-    impl::log("Window Destroyed");
-  }
-} // namespace rwl
+} // namespace rwl::impl

--- a/src/Window/Window.cpp
+++ b/src/Window/Window.cpp
@@ -1,0 +1,24 @@
+#include "rwl/Window/Window.hpp"
+#include "rwl/core.hpp"
+
+namespace rwl {
+  Window::Window(Window &&other)
+      : WinComm(other.m_win, other.m_pos, other.m_dim, other.m_bgColor) {
+    impl::log("Moved a window with window Id: ", m_win);
+    other.m_win = 0;
+  }
+
+  Window::Window(const Window &other)
+      : WinComm(xcb_generate_id(impl::core::conn), other.m_pos, other.m_dim,
+                other.m_bgColor) {}
+
+  Window::Window(const Pos &pos, const Dim &dim, const Color &bgColor)
+      : WinComm(xcb_generate_id(impl::core::conn), pos, dim, bgColor) {}
+
+  Window::~Window() {
+#if RWL_PLATFORM == LINUX
+    xcb_destroy_window(impl::core::conn, m_win);
+#endif
+    impl::log("Window Destroyed");
+  }
+} // namespace rwl

--- a/src/Window/Window.cpp
+++ b/src/Window/Window.cpp
@@ -1,19 +1,41 @@
 #include "rwl/Window/Window.hpp"
-#include "rwl/core.hpp"
 
 namespace rwl {
+  /************************* Private Member Functions *************************/
+  void Window::create() {
+#if RWL_PLATFORM == LINUX
+    uint32_t props[2] = {this->m_bgColor.m_color, XCB_EVENT_MASK_EXPOSURE};
+
+    xcb_create_window(
+        impl::core::conn, impl::core::scr->root_depth, m_win, m_parent.m_win,
+        this->m_pos.x, this->m_pos.y, this->m_dim.width, this->m_dim.height, 3,
+        XCB_WINDOW_CLASS_INPUT_OUTPUT, impl::core::scr->root_visual,
+        XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK, &props);
+    impl::log("Created a window with window Id: ", m_win);
+#endif
+  }
+
+  /******************************* Constructors *******************************/
   Window::Window(Window &&other)
-      : WinComm(other.m_win, other.m_pos, other.m_dim, other.m_bgColor) {
+      : WinComm(other.m_win, other.m_pos, other.m_dim, other.m_bgColor),
+        m_parent(other.m_parent) {
     impl::log("Moved a window with window Id: ", m_win);
     other.m_win = 0;
   }
 
   Window::Window(const Window &other)
       : WinComm(xcb_generate_id(impl::core::conn), other.m_pos, other.m_dim,
-                other.m_bgColor) {}
+                other.m_bgColor),
+        m_parent(other.m_parent) {
+    create();
+  }
 
-  Window::Window(const Pos &pos, const Dim &dim, const Color &bgColor)
-      : WinComm(xcb_generate_id(impl::core::conn), pos, dim, bgColor) {}
+  Window::Window(const Pos &pos, const Dim &dim, const Color &bgColor,
+                 const WinComm &parent)
+      : WinComm(xcb_generate_id(impl::core::conn), pos, dim, bgColor),
+        m_parent(parent) {
+    create();
+  }
 
   Window::~Window() {
 #if RWL_PLATFORM == LINUX

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1,4 +1,5 @@
 #include "rwl/core.hpp"
+#include "rwl/Window/WinComm.hpp"
 #include <cstdlib>
 
 namespace rwl {
@@ -20,6 +21,13 @@ namespace rwl {
     xcb_screen_t *core::scr =
         xcb_setup_roots_iterator(xcb_get_setup(conn)).data;
 #endif
+
+    const impl::WinComm root = makeRoot();
+
+    const WinComm makeRoot() {
+      return WinComm(impl::core::scr->root, {0, 0}, {width(), height()},
+                     rwl::Color::Black);
+    }
   } // namespace impl
 
   void end() {

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -22,13 +22,13 @@ namespace rwl {
         xcb_setup_roots_iterator(xcb_get_setup(conn)).data;
 #endif
 
-    const impl::WinComm root = makeRoot();
-
     const WinComm makeRoot() {
       return WinComm(impl::core::scr->root, {0, 0}, {width(), height()},
                      rwl::Color::Black);
     }
   } // namespace impl
+  
+  const impl::WinComm root = impl::makeRoot();
 
   void end() {
 #if RWL_PLATFORM == LINUX


### PR DESCRIPTION
Moved everything except the constructor and the destructor into a base class of Window called WinComm because now we can use this class to create variable called root which I did. Its declared in core.hpp as extern and defined in core.cpp by using a function called makeRoot() defined inside rwl::impl namespace. As the root doesn't need to be created nor destroyed its of type WinComm.

Added another parameter to the constructor of rwl::Window for selecting the parent of the Window being created. This is of type rwl::impl::WinComm so that root can be passed in.