### PR TITLE
Added a new constructor to rwl::Pen

### DIFF
--- a/include/rwl/Pen.hpp
+++ b/include/rwl/Pen.hpp
@@ -38,8 +38,10 @@ namespace rwl {
     /****************************** Constructor *******************************/
     Pen(Pen &&other);
     Pen(const Pen &other);
-    Pen(const Color &fgColor = Color::Black,
-        const Color &bgColor = Color::Black, const uint32_t &lineWidth = 1,
+    Pen(const Color &color = Color::Black, const uint32_t &lineWidth = 1,
+        const LineStyle &lineStyle = LineStyle::Solid);
+    Pen(const Color &fgColor, const Color &bgColor,
+        const uint32_t &lineWidth = 1,
         const LineStyle &lineStyle = LineStyle::Solid);
 
     /******************************* Operators ********************************/

--- a/src/Pen.cpp
+++ b/src/Pen.cpp
@@ -49,9 +49,13 @@ namespace rwl {
     LOGGING_HELPER("Moved");
   }
 
-  Pen::Pen(const Pen &other) {
-    Pen(other.m_fgColor, other.m_bgColor, other.m_lineWidth, other.m_lineStyle);
-  }
+  Pen::Pen(const Pen &other)
+      : Pen(other.m_fgColor, other.m_bgColor, other.m_lineWidth,
+            other.m_lineStyle) {}
+
+  Pen::Pen(const Color &color, const uint32_t &lineWidth,
+           const LineStyle &lineStyle)
+      : Pen(color, color, lineWidth, lineStyle) {}
 
   Pen::Pen(const Color &fgColor, const Color &bgColor,
            const uint32_t &lineWidth, const LineStyle &lineStyle)


### PR DESCRIPTION
This constructor takes only 1 rwl::Color argument that sets both the foreground and background colors