### PR TITLE
Added 2 more constructors to Pen

### DIFF
--- a/include/rwl/Pen.hpp
+++ b/include/rwl/Pen.hpp
@@ -4,14 +4,6 @@
 #include <xcb/xcb.h>
 
 namespace rwl {
-  namespace impl {
-    template <typename T>
-    class RectPtrComm;
-
-    template <typename T>
-    class RectRefComm;
-  } // namespace impl
-
   class Pen {
   public:
     enum class LineStyle : uint32_t {
@@ -38,8 +30,13 @@ namespace rwl {
     /****************************** Constructor *******************************/
     Pen(Pen &&other);
     Pen(const Pen &other);
+    Pen(const LineStyle &lineStyle);
+    Pen(const uint32_t &lineWidth,
+        const LineStyle &lineStyle = LineStyle::Solid);
+
     Pen(const Color &color = Color::Black, const uint32_t &lineWidth = 1,
         const LineStyle &lineStyle = LineStyle::Solid);
+
     Pen(const Color &fgColor, const Color &bgColor,
         const uint32_t &lineWidth = 1,
         const LineStyle &lineStyle = LineStyle::Solid);

--- a/src/Pen.cpp
+++ b/src/Pen.cpp
@@ -53,6 +53,12 @@ namespace rwl {
       : Pen(other.m_fgColor, other.m_bgColor, other.m_lineWidth,
             other.m_lineStyle) {}
 
+  Pen::Pen(const LineStyle &lineStyle)
+      : Pen(Color::Black, Color::Black, 1, lineStyle) {}
+
+  Pen::Pen(const uint32_t &lineWidth, const LineStyle &lineStyle)
+      : Pen(Color::Black, Color::Black, lineWidth, lineStyle) {}
+
   Pen::Pen(const Color &color, const uint32_t &lineWidth,
            const LineStyle &lineStyle)
       : Pen(color, color, lineWidth, lineStyle) {}


### PR DESCRIPTION
1st constructor takes in the Line width as the first argument and Line Style as the second. This is useful when you don't want to specify the color but just want to set the Line Width and Line Style.

2nd constructor takes in only the Line Style as arguments which is useful like the above when you only want to set the Line style and don't want to bother with the rest.