### PR TITLE
rwl::impl::log now takes the caller name as a parameter.

### DIFF
--- a/include/rwl/Color.hpp
+++ b/include/rwl/Color.hpp
@@ -29,10 +29,7 @@ namespace rwl {
     }
 
 #if RWL_DEBUG == 1
-    inline const uint32_t &getCol() const {
-      impl::log<impl::LogLevel::NoImp>("Returning color as ", m_color);
-      return m_color;
-    }
+    inline const uint32_t &getCol() const { return m_color; }
 #endif
 
     friend Pen;

--- a/include/rwl/Log.hpp
+++ b/include/rwl/Log.hpp
@@ -17,16 +17,18 @@ namespace rwl::impl {
   enum class LogLevel { Error = 1, Warning, Status, NoImp };
 
   template <LogLevel Level = LogLevel::Status, typename... Printables>
-  void log(const Printables &...printables) {
-    if (Level == LogLevel::Error) {
-      puts(RED "[ERROR]: " RESET);
+  constexpr void log(const char *const &callerName = "Unknown",
+                     const Printables &...printables) {
+    if constexpr (Level == LogLevel::Error) {
+      printf(RED "[%s]: " RESET, callerName);
       (std::cout << ... << printables) << '\n';
     } else {
 #if RWL_DEBUG == 1
-      std::cout << (Level == LogLevel::Warning  ? YELLOW "[WARNING]: "
-                    : Level == LogLevel::Status ? GREEN "[STATUS]: "
-                                                : FAINT "[NOT IMP]: ");
-      std::cout << RESET;
+      printf("%s[%s]: " RESET,
+             (Level == LogLevel::Warning  ? YELLOW
+              : Level == LogLevel::Status ? GREEN
+                                          : FAINT),
+             callerName);
       (std::cout << ... << printables) << std::endl;
 #endif
     }

--- a/include/rwl/Pen.hpp
+++ b/include/rwl/Pen.hpp
@@ -61,26 +61,10 @@ namespace rwl {
     bool operator==(const Pen &other);
 
     /******************************** Getters *********************************/
-    inline const Color &getFgColor() const {
-      impl::log<impl::LogLevel::NoImp>("Returning fg color as ",
-                                       this->m_fgColor.colorToStr());
-      return this->m_fgColor;
-    }
-    inline const Color &getBgColor() const {
-      impl::log<impl::LogLevel::NoImp>("Returning bg color as ",
-                                       this->m_bgColor.colorToStr());
-      return this->m_bgColor;
-    }
-    inline const uint32_t &getLineWidth() const {
-      impl::log<impl::LogLevel::NoImp>("Returning line width as ",
-                                       this->m_lineWidth);
-      return this->m_lineWidth;
-    }
-    inline const LineStyle &getLineStyle() const {
-      impl::log<impl::LogLevel::NoImp>(
-          "Returning line style as ", static_cast<uint32_t>(this->m_lineStyle));
-      return this->m_lineStyle;
-    }
+    inline const Color &getFgColor() const { return this->m_fgColor; }
+    inline const Color &getBgColor() const { return this->m_bgColor; }
+    inline const uint32_t &getLineWidth() const { return this->m_lineWidth; }
+    inline const LineStyle &getLineStyle() const { return this->m_lineStyle; }
 
     /******************************** Setters *********************************/
     Pen &setFgColor(const Color &fgColor);
@@ -100,10 +84,7 @@ namespace rwl {
                      const uint32_t &lineWidth, const LineStyle &lineStyle);
 
 #if RWL_PLATFORM == LINUX && RWL_DEBUG == 1
-    inline const xcb_gcontext_t getP() const {
-      impl::log<impl::LogLevel::NoImp>("Returning pen with id: ", m_pen);
-      return this->m_pen;
-    }
+    inline const xcb_gcontext_t getP() const { return this->m_pen; }
 #endif
 
     ~Pen();

--- a/include/rwl/Window/WinComm.hpp
+++ b/include/rwl/Window/WinComm.hpp
@@ -165,8 +165,8 @@ namespace rwl {
       /******************************* Setters *******************************/
       inline WinComm &setPos(const Pos &other) {
         this->m_posDim.pos = other;
-        impl::log<impl::LogLevel::NoImp>("Set Window Position to ",
-                                         this->m_posDim.pos);
+        impl::log<impl::LogLevel::NoImp>("Window",
+                                         "Position = ", this->m_posDim.pos);
         return *this;
       }
       inline WinComm &setX(const int16_t &x) {
@@ -178,8 +178,8 @@ namespace rwl {
 
       inline WinComm &setDim(const Dim &other) {
         this->m_posDim.dim = other;
-        impl::log<impl::LogLevel::NoImp>("Set Window Dimensions to ",
-                                         this->m_posDim.dim);
+        impl::log<impl::LogLevel::NoImp>("Window",
+                                         "Dimensions = ", this->m_posDim.dim);
         return *this;
       }
       inline WinComm &setWidth(const uint16_t &width) {
@@ -191,8 +191,8 @@ namespace rwl {
 
       inline WinComm &setBgColor(const Color &bgColor) {
         this->m_bgColor = bgColor;
-        impl::log<impl::LogLevel::NoImp>("Set Bg Color to ",
-                                         this->m_bgColor.colorToStr());
+        impl::log<impl::LogLevel::NoImp>(
+            "Window", "Bg Color = ", this->m_bgColor.colorToStr());
         return *this;
       }
 

--- a/include/rwl/core.hpp
+++ b/include/rwl/core.hpp
@@ -65,14 +65,8 @@ namespace rwl {
     };
 
 #if RWL_PLATFORM == LINUX && RWL_DEBUG == 1
-    inline xcb_screen_t *&getS() {
-      impl::log<impl::LogLevel::NoImp>("Returning scr.");
-      return core::scr;
-    }
-    inline xcb_connection_t *&getC() {
-      impl::log<impl::LogLevel::NoImp>("Returning the connection.");
-      return core::conn;
-    }
+    inline xcb_screen_t *&getS() { return core::scr; }
+    inline xcb_connection_t *&getC() { return core::conn; }
 #endif
   } // namespace impl
 } // namespace rwl

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -5,6 +5,6 @@ namespace rwl {
   Color::Color(const ColorEnum &color)
       : m_color(color == Black ? impl::core::scr->black_pixel
                                : impl::core::scr->white_pixel) {
-    impl::log("Created a Color with color ", colorToStr());
+    impl::log("Color", "Created with ", colorToStr());
   }
 } // namespace rwl

--- a/src/Pen.cpp
+++ b/src/Pen.cpp
@@ -9,11 +9,6 @@
   uint32_t penMask[] = {this->m_fgColor.m_color, this->m_bgColor.m_color,      \
                         this->m_lineWidth,                                     \
                         static_cast<uint32_t>(this->m_lineStyle), 0}
-#define LOGGING_HELPER(x)                                                      \
-  impl::log("Pen ", (x), ": fg color --> ", this->m_fgColor.colorToStr(),      \
-            ", bg color --> ", this->m_bgColor.colorToStr(),                   \
-            ", line width --> ", this->m_lineWidth, " and line style --> ",    \
-            static_cast<uint32_t>(this->m_lineStyle))
 
 namespace rwl {
   uint32_t Pen::s_valueMask = XCB_GC_FOREGROUND | XCB_GC_BACKGROUND |
@@ -27,7 +22,10 @@ namespace rwl {
 
     xcb_change_gc(impl::core::conn, this->m_pen, this->s_valueMask, penMask);
 
-    LOGGING_HELPER("Changed");
+    impl::log("Pen", "Changed fg color --> ", this->m_fgColor.colorToStr(),
+              ", bg color --> ", this->m_bgColor.colorToStr(),
+              ", line width --> ", this->m_lineWidth, " and line style --> ",
+              static_cast<uint32_t>(this->m_lineStyle));
 #endif
     return *this;
   }
@@ -46,7 +44,8 @@ namespace rwl {
     updateVars(other.m_fgColor, other.m_bgColor, other.m_lineWidth,
                other.m_lineStyle);
     other.m_pen = 0;
-    LOGGING_HELPER("Move Constructed");
+    impl::log("Pen", "Move Constructed");
+    ;
   }
 
   Pen::Pen(const Pen &other)
@@ -73,7 +72,8 @@ namespace rwl {
     xcb_create_gc(rwl::impl::core::conn, this->m_pen, impl::core::scr->root,
                   this->s_valueMask, penMask);
 
-    LOGGING_HELPER("Created");
+    impl::log("Pen", "Created");
+    ;
 #endif
   }
 
@@ -93,7 +93,8 @@ namespace rwl {
       this->m_pen = other.m_pen;
       other.m_pen = 0;
 
-      LOGGING_HELPER("Moved Assigned");
+      impl::log("Pen", "Moved Assigned");
+      ;
     }
 
     return *this;
@@ -150,6 +151,6 @@ namespace rwl {
 #if RWL_PLATFORM == LINUX
     xcb_free_gc(impl::core::conn, m_pen);
 #endif
-    impl::log("Pen Destroyed.");
+    impl::log("Pen", "Destroyed.");
   }
 } // namespace rwl

--- a/src/Window/WinComm.cpp
+++ b/src/Window/WinComm.cpp
@@ -11,8 +11,8 @@ namespace rwl::impl {
     this->setDim(other.m_posDim.dim);
     this->setPos(other.m_posDim.pos);
 
-    impl::log("Set window dim and pos to ", this->m_posDim.dim,
-              this->m_posDim.pos);
+    impl::log("Window", "Dim = ", this->m_posDim.dim,
+              "Pos = ", this->m_posDim.pos);
 
     return *this;
   }
@@ -22,7 +22,7 @@ namespace rwl::impl {
     this->showNoUpdate();
     update();
 
-    impl::log("Don't worry I called update.");
+    impl::log("Window", "Shown");
 
     return *this;
   }
@@ -30,7 +30,7 @@ namespace rwl::impl {
   WinComm &WinComm::showNoUpdate() {
     xcb_map_window(impl::core::conn, m_win);
 
-    impl::log("Mapped window. Better call update if you haven't already!");
+    impl::log("Window", "Shown without updating.");
 
     return *this;
   }
@@ -39,7 +39,7 @@ namespace rwl::impl {
     this->hideNoUpdate();
     update();
 
-    impl::log("Don't worry I called update.");
+    impl::log("Window", "Hidden");
 
     return *this;
   }
@@ -47,7 +47,7 @@ namespace rwl::impl {
   WinComm &WinComm::hideNoUpdate() {
     xcb_unmap_window(impl::core::conn, m_win);
 
-    impl::log("Unmapped WinComm. Call update if you haven't already.");
+    impl::log("Window", "Hidden wihtout updating");
 
     return *this;
   }

--- a/src/Window/Window.cpp
+++ b/src/Window/Window.cpp
@@ -13,7 +13,7 @@ namespace rwl {
         this->m_posDim.dim.height, this->m_borderWidth,
         XCB_WINDOW_CLASS_INPUT_OUTPUT, impl::core::scr->root_visual,
         XCB_CW_BACK_PIXEL | XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK, &props);
-    impl::log("Created a window with window Id: ", m_win);
+    impl::log("Window", "Created with Id: ", m_win);
 #endif
   }
 
@@ -22,7 +22,7 @@ namespace rwl {
       : WinComm(other.m_win, other.m_posDim, other.m_bgColor),
         m_parent(other.m_parent), m_borderWidth(other.m_borderWidth),
         m_borderColor(other.m_borderColor) {
-    impl::log("Moved a window with window Id: ", m_win);
+    impl::log("Window", "Moved.");
     other.m_win = 0;
   }
 
@@ -43,6 +43,6 @@ namespace rwl {
 #if RWL_PLATFORM == LINUX
     xcb_destroy_window(impl::core::conn, m_win);
 #endif
-    impl::log("Window Destroyed");
+    impl::log("Window", "Destroyed");
   }
 } // namespace rwl

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -10,11 +10,11 @@ namespace rwl {
 
       if (int err = xcb_connection_has_error(conn)) {
         impl::log<impl::LogLevel::Error>(
-            "Failed to connect to X Server. Error code ", err);
+            "Core", "Failed to connect to X Server. Error code ", err);
         exit(EXIT_FAILURE);
       }
 
-      impl::log("Connected to X Server.");
+      impl::log("Core", "Connected to X Server.");
 
       return conn;
     })();
@@ -33,7 +33,7 @@ namespace rwl {
   void end() {
 #if RWL_PLATFORM == LINUX
     xcb_disconnect(impl::core::conn);
-    impl::log("Disconnected from X server.");
+    impl::log("Core", "Disconnected from X server.");
 #endif
   }
 
@@ -45,34 +45,22 @@ namespace rwl {
 
   inline uint8_t depth() {
 #if RWL_PLATFORM == LINUX
-    impl::log<impl::LogLevel::NoImp>("Returning screen depth as ",
-                                     impl::core::scr->root_depth);
     return impl::core::scr->root_depth;
 #endif
   }
 
   uint16_t width(const Measurement &m) {
-    if (m == Measurement::Pixels) {
+    if (m == Measurement::Pixels)
 #if RWL_PLATFORM == LINUX
-      impl::log<impl::LogLevel::NoImp>("Returning screen width in pixels as ",
-                                       impl::core::scr->width_in_pixels);
       return impl::core::scr->width_in_pixels;
-    }
-    impl::log<impl::LogLevel::NoImp>("Returning screen width in mm as ",
-                                     impl::core::scr->width_in_millimeters);
     return impl::core::scr->width_in_millimeters;
 #endif
   }
 
   uint16_t height(const Measurement &m) {
-    if (m == Measurement::Pixels) {
+    if (m == Measurement::Pixels)
 #if RWL_PLATFORM == LINUX
-      impl::log<impl::LogLevel::NoImp>("Returning screen height in pixels as ",
-                                       impl::core::scr->height_in_pixels);
       return impl::core::scr->height_in_pixels;
-    }
-    impl::log<impl::LogLevel::NoImp>("Returning screen height in mm as ",
-                                     impl::core::scr->height_in_millimeters);
     return impl::core::scr->height_in_millimeters;
 #endif
   }
@@ -80,14 +68,14 @@ namespace rwl {
   void loop(std::function<void(bool &finished)> func) {
     bool finished = false;
 
-    impl::log("Entered loop.");
+    impl::log("Core", "Entered loop.");
 
     while (!finished) {
       func(finished);
       update();
     }
 
-    impl::log("Exiting loop.");
+    impl::log("Core", "Exiting loop.");
 
     end();
   }


### PR DESCRIPTION
The printed format is now "[<callerName>]: <action>" where stuff within and including the square brackets is green. This brings uniformity to the log messages. Also changed everything to use this format